### PR TITLE
CheerpJ test script updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,15 @@
 .idea/
 target/
 
+# VSCode folder
+.vscode/
+
+# keystore
+*.keystore
+
+# Temp caddy_storage
+src/test/online_test/caddy_storage/
+
 
 ### JAVA ###
 
@@ -104,9 +113,3 @@ $RECYCLE.BIN/
 
 # .nfs files are created when an open file is removed but is still being accessed
 .nfs*
-
-# VSCode folder
-.vscode/
-
-# keystore
-*.keystore

--- a/README.md
+++ b/README.md
@@ -1,49 +1,123 @@
 # Manchester Baby Simulator
 
-A Java-based simulator for the Manchester Baby computer.
+The Manchester Baby Simulator is a Java-based simulator that emulates the Manchester Baby computer—the world’s first stored-program computer. This project offers an interactive way to explore one of computing history’s most significant machines.
 
-See https://davidsharp.com/baby for more details, user documentation etc.
+For more details, background information, and user documentation, please visit [davidsharp.com/baby](https://davidsharp.com/baby).
 
 ![Photo of this simulator running next to the replica machine at the Science and Industry Museum, Manchester, England](https://davidsharp.com/baby/makerfaire.jpg)
 
-## Quick Start
+## Table of Contents
 
-### Prerequisites
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Build](#build)
+- [Run](#run)
+- [Contributing](#contributing)
+- [License](#license)
 
-1. Make sure you have JDK 17 or higher installed. You can install it using brew on macOS:
+
+## Prerequisites
+
+To build and run the Manchester Baby Simulator, you will need the following:
+
+- [Open Java Development Kit (JDK) 17](https://openjdk.org/projects/jdk/17/) or higher
+- [Apache Maven](https://maven.apache.org/download.cgi)
+- [Caddy](https://caddyserver.com/download) (for serving CheerpJ files)
+
+On macOS, you can install these dependencies using [Homebrew](https://brew.sh/):
 
 ```bash
-brew install openjdk@17
+brew install openjdk@17 maven caddy
 ```
 
-2. Ensure Maven is installed. You can install it using brew on macOS:
+On Windows, you can install these dependencies using [Chocolatey](https://chocolatey.org/):
 
 ```bash
-brew install maven
+choco install openjdk maven caddy
 ```
 
-### Setup
+## Setup
 
-1. Clone the repository.
-2. Ensure all dependencies are installed by running:
+1.	**Clone the Repository**: Clone the project to your local machine
+```bash
+git clone https://github.com/davidpsharp/baby.git
+cd baby
+```
+
+2. **Resolve Maven Dependencies**: Ensure all dependencies are installed.
 ```bash
 mvn dependency:resolve
 ```
 
-### Build
-
-To compile and build the project into a runnable JAR file, execute:
-
+3. **Create a Keystore**: Generate a keystore file used by CheerpJ for signing, follow the prompts and remember your chosen password.
 ```bash
-mvn clean package
+keytool -genkeypair -alias baby -keystore baby.keystore -keyalg RSA -keysize 2048 -validity 3650 -storetype PKCS12
 ```
 
-The output JAR file will be located in the target directory.
 
-### Run
+4. **Configure Maven for Signing**: Create (or update) the Maven settings file at ~/.m2/settings.xml with your keystore password. If the file does not exist, create it.
+```bash
+touch ~/.m2/settings.xml
+```
 
-Run the application using the java command:
+Then add the following XML content, replacing YOUR_KEYSTORE_PASSWORD with your actual password.
+```xml
+<settings>
+    <profiles>
+        <profile>
+            <id>sign</id>
+            <properties>
+                <jarsigner.keystore.password>YOUR_KEYSTORE_PASSWORD</jarsigner.keystore.password>
+                <jarsigner.key.password>YOUR_KEYSTORE_PASSWORD</jarsigner.key.password>
+            </properties>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>sign</activeProfile>
+    </activeProfiles>
+</settings>
+```
+
+
+## Build
+
+To compile and package the project into a runnable JAR file, execute:
 
 ```bash
-java -jar target/baby-3.0-SNAPSHOT-jar-with-dependencies.jar
+mvn clean package -Psign 
 ```
+
+After a successful build, the JAR file (with all dependencies bundled) will be available in the target directory.
+
+## Run
+
+### Standalone Java Application
+
+Start the simulator with the following command:
+```bash
+java -jar target/baby-3.0.0-alpha.3-jar-with-dependencies.jar
+```
+
+### CheerpJ Web Application
+
+To run the web version (which uses CheerpJ), execute the provided shell script:
+
+```bash
+./src/test/online_test/online_test.sh
+```
+
+This script launches a local Caddy server to serve the CheerpJ files and automatically opens your default web browser.
+
+## Contributing
+
+Contributions are welcome! If you’d like to improve the simulator:
+
+1.	Fork the repository.
+2.	Create a new branch for your changes.
+3.	Submit a pull request detailing your improvements.
+
+For significant changes, please open an issue first to discuss your ideas.
+
+## License
+
+This project is licensed under the terms of the [GNU General Public License v3](LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.ccs</groupId>
     <artifactId>baby</artifactId>
     <version>3.0.0-alpha.3</version>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
@@ -19,8 +19,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <!-- Needs to be java 8 to be supported by cheerpj for running in a browser as of January 2025 -->
-                    <release>8</release>
+                    <!-- Must use Java 8 for CheerPJ compatibility when running in a browser, as of January 2025. -->
+                    <!-- Note: The <release> flag is not available in Java 8. Use <source>1.8</source> and <target>1.8</target> instead. -->
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 
@@ -107,7 +109,7 @@
             Then build with: mvn clean package -Psign
             -->
 
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jarsigner-plugin</artifactId>
@@ -129,7 +131,6 @@
                     <tsa>http://timestamp.digicert.com</tsa>
                 </configuration>
             </plugin>
-
 
 
         </plugins>

--- a/src/test/online_test/Caddyfile.template
+++ b/src/test/online_test/Caddyfile.template
@@ -1,0 +1,15 @@
+{
+  admin off
+  auto_https off
+  servers {
+    protocols h1
+  }
+  storage file_system {
+    root ./caddy_storage
+  }
+}
+
+http://localhost:{PORT} {
+  root * ../../../target
+  file_server
+}

--- a/src/test/online_test/index.html
+++ b/src/test/online_test/index.html
@@ -1,21 +1,19 @@
-
-
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
+<head>
+    <meta charset="utf-8"/>
     <title>Baby Simulator - v3.0 Alpha Test Version</title>
     <script src="https://cjrtnc.leaningtech.com/3.0/cj3loader.js"></script>
     <link rel="icon" href="/classes/icons/baby.png">
-  </head>
-  <body>
-    <script>
-      (async function () {
-        await cheerpjInit({ logCanvasUpdates:true, clipboardMode:"system" });
+</head>
+<body>
+<script>
+    (async function () {
+        await cheerpjInit({logCanvasUpdates: true, clipboardMode: "system"});
         // set cheerpj size to be the same size as the window in Baby.java
         cheerpjCreateDisplay(700, 950);
         await cheerpjRunJar("/app/baby-3.0.0-alpha.3.jar");
-      })();
-    </script>
-  </body>
+    })();
+</script>
+</body>
 </html>

--- a/src/test/online_test/online_test.sh
+++ b/src/test/online_test/online_test.sh
@@ -1,16 +1,98 @@
+#!/bin/bash
+set -e  # Exit immediately if a command fails
 
-# Mac OS shell script to copy HTML file to target, open web browser and launch a Python3 web server to test out cheerpj serving the root of target folder 
-# Run this script from current working directory of: baby/src/test/online_test 
+# Shell script to set up and test a Caddy web server on macOS
+# - Copies an HTML file to the target directory
+# - Finds an available port
+# - Launches a Caddy web server
+# - Opens a web browser to test serving the root of the target folder.
 
-# change current working directory to be the location of this script
-cd "$(dirname "$0")"
+# Run this script from the directory: baby/src/test/online_test
 
-# install the index.html in target folder
-cp index.html ../../../target/index.html
+# Change to the script's directory
+cd "$(dirname "$0")" || { echo "Error: Could not change directory"; exit 1; }
 
-# launch the web browser which will retry to connect to the web server which we start in the next step
-open -a open -a Google\ Chrome http://localhost:8080
+# Check for required commands
+for cmd in lsof sed nc open; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: Required command '$cmd' not found." >&2
+    exit 1
+  fi
+done
 
-# launch the web server, serving the root of the target folder
-python3 -m http.server 8080 -d ../../../target/
+# Check for the Caddy binary
+CADDY_BIN="/opt/homebrew/bin/caddy"
+if ! command -v "$CADDY_BIN" &>/dev/null; then
+  echo "Error: Caddy binary not found at $CADDY_BIN" >&2
+  exit 1
+fi
 
+# Ensure required files exist
+for file in index.html Caddyfile.template; do
+  if [[ ! -f "$file" ]]; then
+    echo "Error: $file not found!" >&2
+    exit 1
+  fi
+done
+
+# Copy index.html to the target folder
+TARGET_DIR="../../../target"
+mkdir -p "$TARGET_DIR"  # Ensure the directory exists
+cp index.html "$TARGET_DIR/index.html"
+
+# Find an available port starting from 8080 (limit to avoid infinite loops)
+PORT=8080
+MAX_PORT=8100
+while lsof -i :"$PORT" &>/dev/null; do
+  ((PORT++))
+  if (( PORT > MAX_PORT )); then
+    echo "Error: No available ports in range 8080-$MAX_PORT" >&2
+    exit 1
+  fi
+done
+echo "Using port $PORT"
+
+# Create a temporary Caddy configuration file
+CADDY_FILE=$(mktemp "Caddyfile_XXXX")
+
+# Replace {PORT} in the template and save it to the temp Caddyfile
+sed "s/{PORT}/$PORT/g" Caddyfile.template > "$CADDY_FILE"
+
+# Format the Caddyfile (optional but ensures consistency)
+"$CADDY_BIN" fmt --overwrite "$CADDY_FILE"
+
+# Function to clean up on exit
+cleanup() {
+  echo "Stopping Caddy server..."
+  if [[ -n "${SERVER_PID-}" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -f "$CADDY_FILE"
+}
+
+# Trap exit signals to cleanup properly
+trap cleanup EXIT SIGINT SIGTERM
+
+# Launch Caddy in the background with resume disabled.
+"$CADDY_BIN" run --config "$CADDY_FILE" --resume=false &
+SERVER_PID=$!
+
+# Wait for the server to be ready with a timeout (max 10 seconds)
+echo "Waiting for server to start on port $PORT..."
+MAX_ATTEMPTS=20
+ATTEMPT=0
+while ! nc -z localhost "$PORT"; do
+  sleep 0.5
+  ((ATTEMPT++))
+  if (( ATTEMPT >= MAX_ATTEMPTS )); then
+    echo "Error: Server did not start within 10 seconds." >&2
+    exit 1
+  fi
+done
+echo "Caddy server is up and running!"
+
+# Open the default web browser to the server URL
+open "http://localhost:$PORT"
+
+# Wait for the server process to finish
+wait "$SERVER_PID"


### PR DESCRIPTION
Made some improvements to the CheerpJ test shell script and improved README for future contributors to get it running locally.

The key change is that I swopped out Python for Caddy. When running on my default browser (Firefox), I got some range header errors. I tried to fix it with a custom Flask app, but that fell apart a bit. Turns out Caddy has range headers support out the box and it's on homebrew.

Very cool that it works easily in the browser!